### PR TITLE
Fix Rack compatibility issues across versions 2.x and 3.x

### DIFF
--- a/lib/mcp/transports/authenticated_rack_transport.rb
+++ b/lib/mcp/transports/authenticated_rack_transport.rb
@@ -52,7 +52,7 @@ module FastMcp
           }
         )
 
-        [401, { 'Content-Type' => 'application/json' }, [body]]
+        [401, CONTENT_TYPE_JSON_HEADERS.dup, [body]]
       end
 
       def extract_request_id(request)
@@ -60,7 +60,7 @@ module FastMcp
 
         begin
           body = request.body.read
-          request.body.rewind
+          request.body.rewind if request.body.respond_to?(:rewind)
           JSON.parse(body)['id']
         rescue StandardError
           nil

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,9 @@ require 'fast_mcp'
 
 Bundler.require(:default, :test)
 
+# Load support files
+Dir[File.expand_path('support/**/*.rb', __dir__)].each { |f| require f }
+
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = '.rspec_status'

--- a/spec/support/default_ok_response_matcher.rb
+++ b/spec/support/default_ok_response_matcher.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+# Matcher for default OK responses (non-JSON-RPC)
+# Used for testing plain text responses from non-MCP endpoints
+RSpec::Matchers.define :be_default_ok_response do
+  match do |actual|
+    @actual = actual
+    
+    status_matches? && content_type_matches? && body_matches?
+  end
+  
+  failure_message do
+    messages = ["expected a default OK response"]
+    
+    unless status_matches?
+      messages << "  Status: expected 200, got #{@actual.status}"
+    end
+    
+    unless content_type_matches?
+      messages << "  Content-Type: expected 'text/plain', got '#{@actual.headers['Content-Type']}'"
+    end
+    
+    unless body_matches?
+      messages << "  Body: expected 'OK', got #{@actual.body.inspect}"
+    end
+    
+    messages.join("\n")
+  end
+  
+  failure_message_when_negated do
+    "expected not to be a default OK response (status: 200, content-type: text/plain, body: 'OK')"
+  end
+  
+  description do
+    "be a default OK response (200 OK with text/plain content)"
+  end
+  
+  private
+  
+  def status_matches?
+    @actual.status == 200
+  end
+  
+  def content_type_matches?
+    @actual.headers['Content-Type'] == 'text/plain'
+  end
+  
+  def body_matches?
+    @actual.body == 'OK'
+  end
+end

--- a/spec/support/json_rpc_error_matcher.rb
+++ b/spec/support/json_rpc_error_matcher.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+# Matcher specifically for JSON-RPC error responses
+# Provides focused testing for error codes, messages, and IDs
+# Use this when testing error conditions for clearer intent and better error messages
+RSpec::Matchers.define :be_json_rpc_error do
+  match do |actual|
+    @actual = actual
+    @expected_status = @expected_status || 200
+    
+    status_matches? && content_type_matches? && body_matches_error?
+  end
+  
+  chain :with_error_code do |code|
+    @expected_code = code
+  end
+  
+  chain :with_message do |message|
+    @expected_message = message
+  end
+  
+  chain :with_id do |id|
+    @expected_id = id
+  end
+  
+  chain :with_status do |status|
+    @expected_status = status
+  end
+  
+  failure_message do
+    messages = ["expected a JSON-RPC error response"]
+    
+    unless status_matches?
+      messages << "  Status: expected #{@expected_status}, got #{@actual.status}"
+    end
+    
+    unless content_type_matches?
+      messages << "  Content-Type: expected 'application/json', got '#{@actual.headers['Content-Type']}'"
+    end
+    
+    if content_type_matches? && !body_matches_error?
+      actual_body = parse_actual_body
+      
+      if actual_body.is_a?(Hash) && actual_body['error']
+        error = actual_body['error']
+        messages << format_error_diff(error)
+        
+        if @expected_id && actual_body['id'] != @expected_id
+          messages << "  ID: expected #{@expected_id.inspect}, got #{actual_body['id'].inspect}"
+        end
+      else
+        messages << "  Body: expected JSON-RPC error, but got #{actual_body.inspect}"
+      end
+    end
+    
+    messages.join("\n")
+  end
+  
+  failure_message_when_negated do
+    desc = "expected not to be a JSON-RPC error"
+    desc += " with code #{@expected_code}" if @expected_code
+    desc += " and message '#{@expected_message}'" if @expected_message
+    desc
+  end
+  
+  description do
+    desc = "be a JSON-RPC error"
+    desc += " with code #{@expected_code}" if @expected_code
+    desc += " and message '#{@expected_message}'" if @expected_message
+    desc += " (status: #{@expected_status})" if @expected_status != 200
+    desc
+  end
+  
+  private
+  
+  def status_matches?
+    @actual.status == @expected_status
+  end
+  
+  def content_type_matches?
+    @actual.headers['Content-Type'] == 'application/json'
+  end
+  
+  def body_matches_error?
+    actual_body = parse_actual_body
+    return false unless actual_body.is_a?(Hash)
+    return false unless actual_body['jsonrpc'] == '2.0'
+    return false unless actual_body['error'].is_a?(Hash)
+    
+    error = actual_body['error']
+    
+    # Check code if provided
+    if @expected_code
+      return false unless error['code'] == @expected_code
+    end
+    
+    # Check message if provided
+    if @expected_message
+      return false unless error['message'] == @expected_message
+    end
+    
+    # Check id if provided
+    if @expected_id
+      return false unless actual_body['id'] == @expected_id
+    end
+    
+    true
+  end
+  
+  def parse_actual_body
+    return nil if @actual.body.empty?
+    JSON.parse(@actual.body)
+  rescue JSON::ParserError => e
+    { 'json_parse_error' => e.message, 'raw_body' => @actual.body }
+  end
+  
+  def format_error_diff(actual_error)
+    messages = []
+    
+    if @expected_code && actual_error['code'] != @expected_code
+      messages << "  Error code: expected #{@expected_code}, got #{actual_error['code']}"
+    elsif @expected_code.nil? && actual_error['code']
+      messages << "  Error code: #{actual_error['code']}"
+    end
+    
+    if @expected_message && actual_error['message'] != @expected_message
+      messages << "  Error message: expected '#{@expected_message}', got '#{actual_error['message']}'"
+    elsif !@expected_message && actual_error['message']
+      messages << "  Error message: '#{actual_error['message']}'"
+    end
+    
+    messages.join("\n")
+  end
+end

--- a/spec/support/json_rpc_response_matcher.rb
+++ b/spec/support/json_rpc_response_matcher.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+# Matcher for general JSON-RPC 2.0 responses (success or error)
+# Validates that responses follow the JSON-RPC 2.0 specification:
+# - Must be valid JSON with Content-Type: application/json
+# - Must be a Hash containing 'jsonrpc' => '2.0'
+# - Empty body is allowed for success responses
+# For error-specific tests, prefer the be_json_rpc_error matcher
+RSpec::Matchers.define :be_json_rpc_response do
+  match do |actual|
+    @actual = actual
+    @expected_status = expected_status
+    @expected_body = @chained_body || ''
+    
+    status_matches? && content_type_matches? && body_matches?
+  end
+  
+  chain :with_status do |status|
+    @expected_status = status
+  end
+  
+  chain :with_body do |body|
+    @chained_body = body
+  end
+  
+  failure_message do
+    messages = ["expected a JSON-RPC response"]
+    
+    unless status_matches?
+      messages << "  Status: expected #{@expected_status}, got #{@actual.status}"
+    end
+    
+    unless content_type_matches?
+      messages << "  Content-Type: expected 'application/json', got '#{@actual.headers['Content-Type']}'"
+    end
+    
+    unless body_matches?
+      if @expected_body.nil? || @expected_body == ''
+        messages << "  Body: expected empty, got #{@actual.body.inspect}"
+      else
+        actual_body = parse_actual_body
+        if !actual_body.is_a?(Hash)
+          messages << "  Body: expected valid JSON-RPC response, got #{actual_body.inspect}"
+        elsif actual_body['jsonrpc'] != '2.0'
+          messages << "  Body: expected JSON-RPC version 2.0, got #{actual_body['jsonrpc'].inspect}"
+        else
+          messages << format_body_diff(actual_body)
+        end
+      end
+    end
+    
+    messages.join("\n")
+  end
+  
+  failure_message_when_negated do
+    desc = "expected not to be a JSON-RPC response"
+    desc += " with status #{@expected_status}" if @expected_status != 200
+    desc += " and body #{@expected_body.inspect}" unless @expected_body.nil? || @expected_body == ''
+    desc
+  end
+  
+  description do
+    desc = "be a JSON-RPC response"
+    desc += " with status #{@expected_status}" if @expected_status != 200
+    desc += " with body #{format_expected_body}" unless @expected_body.nil? || @expected_body == ''
+    desc
+  end
+  
+  private
+  
+  def expected_status
+    @expected_status || 200
+  end
+  
+  def status_matches?
+    @actual.status == expected_status
+  end
+  
+  def content_type_matches?
+    @actual.headers['Content-Type'] == 'application/json'
+  end
+  
+  def body_matches?
+    if @expected_body.nil? || @expected_body == ''
+      @actual.body.empty?
+    else
+      actual_body = parse_actual_body
+      return false unless actual_body.is_a?(Hash)
+      return false unless actual_body['jsonrpc'] == '2.0'
+      actual_body == @expected_body
+    end
+  end
+  
+  def parse_actual_body
+    return nil if @actual.body.empty?
+    JSON.parse(@actual.body)
+  rescue JSON::ParserError => e
+    { 'json_parse_error' => e.message, 'raw_body' => @actual.body }
+  end
+  
+  def format_body_diff(actual_body)
+    "  Body: expected #{@expected_body.inspect}\n        but got #{actual_body.inspect}"
+  end
+  
+  def format_expected_body
+    @expected_body.inspect
+  end
+end


### PR DESCRIPTION
# Fix Rack compatibility issues across versions 2.x and 3.x

## Summary

This PR addresses compatibility issues between Rack 2.x and 3.x versions in the FastMCP transport layer. The changes ensure that the gem works correctly with both major versions of Rack while maintaining backward compatibility.

## Problem

The codebase had several incompatibilities with different Rack versions:
1. **Header handling**: Rack 3.x introduces `Rack::Headers` while Rack 2.x uses `Rack::Utils::HeaderHash`
2. **Hijack API**: The `rack.hijack` interface changed between versions
3. **Request body handling**: Some edge cases around body rewinding needed to be addressed
4. **Test infrastructure**: Tests were not properly using Rack's mock request/response utilities

## Solution

### 1. Dynamic Header Class Selection
- Added version detection to use the appropriate header class based on Rack version
- Properly freeze and duplicate headers to prevent modification issues
- Consolidated header definitions into constants for consistency

### 2. Rack Hijack Compatibility
- Fixed SSE connection handling to work with both Rack 2.x and 3.x
- Rack 3.x: `rack.hijack` returns IO directly
- Rack 2.x: IO is available via `rack.hijack_io` after calling `rack.hijack`

### 3. Request Body Safety
- Added safety check for `rewind` method availability on request body
- Prevents errors when dealing with non-rewindable streams

### 4. Improved Test Infrastructure
- Introduced custom RSpec matchers for cleaner and more maintainable tests:
  - `be_json_rpc_response`: Validates general JSON-RPC 2.0 responses
  - `be_json_rpc_error`: Specifically tests error responses with chainable assertions
  - `be_default_ok_response`: Tests plain text OK responses
- Updated all transport specs to use `Rack::MockRequest` and `Rack::MockResponse`
- Added `Rack::Lint` middleware in tests to ensure Rack compliance

## Changes

### Modified Files
- `.ruby-version`: Updated to Ruby 3.4.2
- `lib/mcp/transports/rack_transport.rb`: Main compatibility fixes
- `lib/mcp/transports/authenticated_rack_transport.rb`: Header handling updates
- `spec/mcp/transports/*_spec.rb`: Complete test suite overhaul
- `spec/spec_helper.rb`: Added support file loading

### New Files
- `spec/support/json_rpc_response_matcher.rb`: General JSON-RPC response matcher
- `spec/support/json_rpc_error_matcher.rb`: Error-specific matcher with chaining
- `spec/support/default_ok_response_matcher.rb`: Plain text response matcher

## Testing

All tests have been updated and verified to pass with both:
- Rack 2.x (tested with 2.2.x)
- Rack 3.x (tested with 3.0.x and 3.1.x)

The custom matchers provide better test readability and more informative failure messages:

```ruby
# Before
expect(result[0]).to eq(401)
expect(JSON.parse(result[2].first)['error']['code']).to eq(-32_000)

# After
expect(result).to be_json_rpc_error
  .with_error_code(-32_000)
  .with_message('Unauthorized: Invalid or missing authentication token')
  .with_status(401)
```

## Breaking Changes

None. All changes maintain backward compatibility.

## Future Considerations

- The header handling approach could be extracted into a separate compatibility module if more Rack version differences emerge
- Consider adding CI matrix testing for multiple Rack versions
- The custom matchers could be packaged as a separate testing utility gem if they prove useful in other contexts
